### PR TITLE
feat: Descriptions on the same line

### DIFF
--- a/shortlinks/templates/index.html
+++ b/shortlinks/templates/index.html
@@ -3,7 +3,7 @@
 
 <ul>
 {{range .Shortlinks}}
-<li><a href="{{.To}}">{{.From}}</a> [<a href="/_edit/?from={{.From}}">edit</a>] {{if ne .Description ""}}<p>{{.Description}}</p>{{end}}</li>
+<li><a href="{{.To}}">{{.From}}</a> [<a href="/_edit/?from={{.From}}">edit</a>] {{if ne .Description ""}} {{.Description}}{{end}}</li>
 {{end}}
 </ul>
 


### PR DESCRIPTION
Removes line break for description, which renders nicer when you have many links.