### PR TITLE
feat: Missing links redirect to search results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.10.10
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.1
 	github.com/frioux/dh v0.0.0-20220615053643-86559e96dc25
+	github.com/hbollon/go-edlib v1.6.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/mattn/go-sqlite3 v1.14.16
 	tailscale.com v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hbollon/go-edlib v1.6.0 h1:ga7AwwVIvP8mHm9GsPueC0d71cfRU/52hmPJ7Tprv4E=
+github.com/hbollon/go-edlib v1.6.0/go.mod h1:wnt6o6EIVEzUfgbUZY7BerzQ2uvzp354qmS2xaLkrhM=
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 h1:aSVUgRRRtOrZOC1fYmY9gV0e9z/Iu+xNVSASWjsuyGU=
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3/go.mod h1:5PC6ZNPde8bBqU/ewGZig35+UIZtw9Ytxez8/q5ZyFE=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/shortlinks/handler_index.go
+++ b/shortlinks/handler_index.go
@@ -1,7 +1,9 @@
 package shortlinks
 
 import (
+	"github.com/hbollon/go-edlib"
 	"net/http"
+	"sort"
 	"strings"
 )
 
@@ -9,12 +11,56 @@ type index struct {
 	Shortlinks []Shortlink
 }
 
+type search struct {
+	Path       string
+	Shortlinks []Shortlink
+}
+
 func (i index) Title() string  { return "go links" }
 func (i index) To() string     { return "" }
 func (i index) From() string   { return "" }
 func (i index) Submit() string { return "Create" }
-
 func (i index) Description() string { return "" }
+
+func (s search) Title() string  { return "go links" }
+func (s search) To() string     { return "" }
+func (s search) From() string   { return "" }
+func (s search) Submit() string { return "Create" }
+func (s search) Description() string { return "" }
+
+type scoredShortlink struct {
+	shortlink Shortlink
+	score     int
+}
+type scoredShortLinksWrapper []scoredShortlink
+
+func (s scoredShortLinksWrapper) Len() int           { return len(s) }
+func (s scoredShortLinksWrapper) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s scoredShortLinksWrapper) Less(i, j int) bool { return s[i].score < s[j].score }
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+func possibleMatches(shortlinks []Shortlink, path string, resultSize int) []Shortlink {
+	scoredShortlinks := make([]scoredShortlink, len(shortlinks))
+
+	for i, sl := range shortlinks {
+		score := edlib.DamerauLevenshteinDistance(path, sl.From)
+		scoredShortlinks[i] = scoredShortlink{shortlink: sl, score: score}
+	}
+
+	sort.Sort(scoredShortLinksWrapper(scoredShortlinks))
+
+	for i, sl := range scoredShortlinks {
+		shortlinks[i] = sl.shortlink
+	}
+
+	return shortlinks[:min(resultSize, len(shortlinks))]
+}
 
 func indexHandler(db PublicDB) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -31,15 +77,33 @@ func indexHandler(db PublicDB) http.Handler {
 				return
 			}
 			return
-		}
+		} else {
+			path := strings.TrimPrefix(r.URL.Path, "/")
+			sl, err := db.Shortlink(path)
+			if err != nil {
+				_500(w, err)
+				return
+			}
 
-		sl, err := db.Shortlink(strings.TrimPrefix(r.URL.Path, "/"))
-		if err != nil {
-			_500(w, err)
-			return
-		}
-		w.Header().Add("Location", sl.To)
-		w.WriteHeader(302)
+			emptyShortLink := Shortlink{}
+			if sl == emptyShortLink {
+				sls, err := db.AllShortlinks()
+				if err != nil {
+					_500(w, err)
+					return
+				}
+				v := search{Path: path, Shortlinks: possibleMatches(sls, path, 20)}
 
+				w.WriteHeader(404)
+				if err := tpl.ExecuteTemplate(w, "search.html", v); err != nil {
+					_500(w, err)
+					return
+				}
+				return
+			} else {
+				w.Header().Add("Location", sl.To)
+				w.WriteHeader(302)
+			}
+		}
 	})
 }

--- a/shortlinks/templates/public_index.html
+++ b/shortlinks/templates/public_index.html
@@ -2,7 +2,7 @@
 
 <ul>
 {{range .Shortlinks}}
-<li><a href="{{.To}}">{{.From}}</a>{{if ne .Description ""}}<p>{{.Description}}</p>{{end}}</li>
+<li><a href="{{.To}}">{{.From}}</a>{{if ne .Description ""}} {{.Description}}{{end}}</li>
 {{end}}
 </ul>
 

--- a/shortlinks/templates/search.html
+++ b/shortlinks/templates/search.html
@@ -1,7 +1,7 @@
 {{ template "z_header.html" .}}
 {{ template "form.html" .}}
 
-<p><b>{{.Path}}</b> wasn't found, did you mean one of these?:</p>
+<p><b>{{.Path}}</b> wasn't found, did you mean one of these?</p>
 
 <ul>
 {{range .Shortlinks}}

--- a/shortlinks/templates/search.html
+++ b/shortlinks/templates/search.html
@@ -1,0 +1,14 @@
+{{ template "z_header.html" .}}
+{{ template "form.html" .}}
+
+<p><b>{{.Path}}</b> wasn't found, did you mean one of these?:</p>
+
+<ul>
+{{range .Shortlinks}}
+<li><a href="{{.To}}">{{.From}}</a> {{if ne .Description ""}} {{.Description}}{{end}}</li>
+{{end}}
+</ul>
+
+<div><a href="/">or go to the index</a></div>
+<br>
+{{ template "z_footer.html" .}}

--- a/storage/dynamodbstorage/dynamodbstorage.go
+++ b/storage/dynamodbstorage/dynamodbstorage.go
@@ -62,14 +62,12 @@ func mustUnmarshal(av map[string]types.AttributeValue, d interface{}) {
 }
 
 func (cl *Client) Shortlink(from string) (shortlinks.Shortlink, error) {
-	var ret shortlinks.Shortlink
-
 	gio, err := cl.DB.GetItem(context.Background(), &dynamodb.GetItemInput{
 		TableName: aws.String(cl.Table),
 		Key:       mustMarshal(shortlink{PK: pkShortlink, From: from}),
 	})
 	if err != nil {
-		return ret, err
+		return shortlinks.Shortlink{}, err
 	}
 
 	var s shortlink


### PR DESCRIPTION
Problem

When you go to a missing link it doesnt return an
error or actually redirect you.

SQL DB errors out on missing while the Dynamo 
DB returns default struct.

Solution

When a missing link is hit, return a 404 page
with s reasonable search result (top 20 ordered
by edit distance) to get to the intended page.

Fix the SQL version to return a default struct 
when missing to be consistent.

Result

If you typo when going to a link you will be
able to find what you're looking for if the
correct link is similar to what you typed.
You will also get a 404 which is more correct.