### PR TITLE
feature: Add variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ $ shortlinks --listen :8081 --db file:shortlinks.db
 
 Then navigate to `http://localhost:8081` and create your first shortlink!
 
+## Variables
+
+In addition to simple links, a single `%s` can be added to a link to be filled out based on what the input URL is.
+
+Here's a table of some examples:
+
+| From  | Query                          | To                                | Result                                            |
+|-------|--------------------------------|-----------------------------------|---------------------------------------------------|
+| j     | j                              | https://atlassian.net/browse/%s   | https://atlassian.net/browse/                     |
+| j     | j/JIRA-000                     | https://atlassian.net/browse/%s   | https://atlassian.net/browse/JIRA-000             |
+| some  | some/firstquery/secondquery    | https://some.url/%s/else          | https://some.url/firstquery/secondquery/else      |
+| other | other/firstquery/secondquery   | https://some.url/%s/else/%s       | https://some.url/firstquery/secondquery/else/%s   |
+
+Note that only 1 substution is performed. If more than one `%s` is in the To value, the rest will be ignored.
+If no argument is given then empty string, "" is used.
+
 ## Custom Drivers
 
 This tool is built to be easy to run using SQLite.  If you want to use some

--- a/shortlinks/handler_index_test.go
+++ b/shortlinks/handler_index_test.go
@@ -1,0 +1,40 @@
+package shortlinks
+
+import (
+	"testing"
+)
+
+func TestSubstitute(t *testing.T) {
+	type test struct {
+		path     string
+		to       string
+		expected string
+	}
+
+	cases := []test{
+		{path: "/path", to: "https://url.com", expected: "https://url.com"},
+		{path: "/path", to: "https://url.com/", expected: "https://url.com/"},
+		{path: "/path/", to: "https://url.com", expected: "https://url.com"},
+		{path: "/path", to: "https://url.com/q=%s", expected: "https://url.com/q="},
+		{path: "/path/sub", to: "https://url.com", expected: "https://url.com"},
+		{path: "/path/sub1/sub2", to: "https://url.com", expected: "https://url.com"},
+		{path: "/path/sub", to: "https://url.org/q=%s", expected: "https://url.org/q=sub"},
+		{path: "/path/sub1/sub2", to: "https://url.org/q=%s&t=%s", expected: "https://url.org/q=sub1/sub2&t=%s"},
+		{path: "/path/sub1/sub2", to: "https://url.org/q=%s&", expected: "https://url.org/q=sub1/sub2&"},
+		{path: "/path/sub1/", to: "https://url.org/q=%s&t=%s", expected: "https://url.org/q=sub1/&t=%s"},
+		{path: "/path/sub1", to: "https://url.org/q=%s&t=%s", expected: "https://url.org/q=sub1&t=%s"},
+		{path: "/j", to: "https://atlassian.net/browse/%s", expected: "https://atlassian.net/browse/"},
+		{path: "/j/JIRA-000", to: "https://atlassian.net/browse/%s", expected: "https://atlassian.net/browse/JIRA-000"},
+		{path: "/some/firstquery/secondquery", to: "https://some.url/%s/else", expected: "https://some.url/firstquery/secondquery/else"},
+		{path: "/other/firstquery/secondquery", to: "https://some.url/%s/else/%s", expected: "https://some.url/firstquery/secondquery/else/%s"},
+	}
+
+	for _, test := range cases {
+		s := Shortlink{To: test.to}
+		_, substitutions := split(test.path)
+		url := substitute(s, substitutions)
+		if url != test.expected {
+			t.Errorf("URL as a result of substitute did match expected,\npath: %q\nto: %q\nactual url:\t\t%q\nexpected url:\t%q", test.path, test.to, url, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Problem

We're unable to add dynamic links due to no support for variables. Tailscale, Golinks, and Trotto all support variables like these, each in their own ways, but we have no support for them.

Solution

Add support for variables in URLs. Taking some of the simplicity from Golinks and Trotto instead of full template support in Tailscale, we opted to go with a simple %s from Trotto due to the familiarity for those who have used simple format strings over the [*] from golinks. This supports only a single substitution per feedback from @frioux.

Result

Support for a sinple variable is available and is simple to use, it's documented in the readme and with an easy to read test.