### PR TITLE
fix: off-by-one when parsing

### DIFF
--- a/shortlinks/handler_index.go
+++ b/shortlinks/handler_index.go
@@ -70,7 +70,7 @@ func split(path string) (string, string) {
 	if indexOfSlash == -1 {
 		return path, ""
 	}
-	prefix := path[0 : indexOfSlash-1]
+	prefix := path[0 : indexOfSlash]
 	suffix := path[indexOfSlash+1:]
 	return prefix, suffix
 

--- a/shortlinks/handler_index_test.go
+++ b/shortlinks/handler_index_test.go
@@ -1,6 +1,7 @@
 package shortlinks
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -31,8 +32,12 @@ func TestSubstitute(t *testing.T) {
 
 	for _, test := range cases {
 		s := Shortlink{To: test.to}
-		_, substitutions := split(test.path)
-		url := substitute(s, substitutions)
+		prefix, substitution := split(test.path)
+		expectedPrefix := strings.Split(prefix, "/")[0]
+		if prefix != expectedPrefix {
+			t.Errorf("Expected path: %q to have prefix %q but found %q", test.path, expectedPrefix, prefix)
+		}
+		url := substitute(s, substitution)
 		if url != test.expected {
 			t.Errorf("URL as a result of substitute did match expected,\npath: %q\nto: %q\nactual url:\t\t%q\nexpected url:\t%q", test.path, test.to, url, test.expected)
 		}


### PR DESCRIPTION
Small error causing the prefix to not be correct when substituting. This caused it to lookup "" in the DB when there was a substitution for a single character long name or missing the last character in the case of longer names.