### PR TITLE
bump go version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/frioux/shortlinks
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.17.6


### PR DESCRIPTION
Some of the dependencies now require go 1.20 so up the main project too to avoid issues.